### PR TITLE
Add status code and Content-Type for each responses

### DIFF
--- a/cosmos_rest_faucet.py
+++ b/cosmos_rest_faucet.py
@@ -203,14 +203,14 @@ async def get_balance():
     if 'address' not in request_dict or \
             'chain' not in request_dict:
         return json.dumps({'status': 'fail',
-                           'message': 'Error: address or chain_id not specified'})
+                           'message': 'Error: address or chain_id not specified'}), 400, {'Content-Type': 'application/json'}
     try:
         address = request_dict['address']
         chain = request_dict['chain']
         if chain not in chain_ids:
             return json.dumps({'status': 'fail',
                                'message': 'Error: invalid chain; '
-                               f'specify one of the following: {chain_ids}'})
+                               f'specify one of the following: {chain_ids}'}), 400, {'Content-Type': 'application/json'}
         await gaia.check_address(address)
         balance = await balance_request(address=address, testnet=testnets[chain])
         response = {
@@ -219,14 +219,14 @@ async def get_balance():
             'balance': balance,
             'status': 'success'
         }
-        return json.dumps(response)
+        return json.dumps(response), 200, {'Content-Type': 'application/json'}
     except KeyError as key:
         logging.critical('Key could not be found: %s', key)
     except subprocess.CalledProcessError as cpe:
         msg = cpe.stderr.split('\n')[0]
         if 'parse' in cpe.cmd:
             msg = 'Error: invalid address'
-        return json.dumps({'status': 'fail', 'message': msg})
+        return json.dumps({'status': 'fail', 'message': msg}), 400, {'Content-Type': 'application/json'}
 
 
 @app.route('/request', methods=['GET'])
@@ -239,14 +239,14 @@ async def send_tokens():
     if 'address' not in request_dict or \
        'chain' not in request_dict:
         return json.dumps({'status': 'fail',
-                           'message': 'Error: address or chain_id not specified'})
+                           'message': 'Error: address or chain_id not specified'}), 400, {'Content-Type': 'application/json'}
     try:
         address = request_dict['address']
         chain = request_dict['chain']
         if chain not in chain_ids:
             return json.dumps({'status': 'fail',
                                'message': 'Error: invalid chain; '
-                               f'specify one of the following: {chain_ids}'})
+                               f'specify one of the following: {chain_ids}'}), 400, {'Content-Type': 'application/json'}
         await gaia.check_address(address)
         amount, transfer = await token_request(address=address, testnet=testnets[chain])
         if amount:
@@ -262,15 +262,15 @@ async def send_tokens():
                 'status': 'fail',
                 'message': transfer
             }
-        return json.dumps(response)
+        return json.dumps(response), 200, {'Content-Type': 'application/json'}
     except KeyError as key_error:
         logging.critical('Key could not be found: %s', key_error)
-        return "Missing key"
+        return json.dumps({'status': 'fail', 'message': 'Missing key'}), 400, {'Content-Type': 'application/json'}
     except subprocess.CalledProcessError as cpe:
         msg = cpe.stderr.split('\n')[0]
         if 'parse' in cpe.cmd:
             msg = 'Error: invalid address'
-        return json.dumps({'status': 'fail', 'message': msg})
+        return json.dumps({'status': 'fail', 'message': msg}), 400, {'Content-Type': 'application/json'}
 
 
 @app.route('/', methods=['GET'])


### PR DESCRIPTION
### Why:

Closes [Issue #6](https://github.com/hyphacoop/cosmos-rest-faucet/issues/6).

### What's being changed:

Added status code (`200`, or `400`) and `{'Content-Type': 'application/json'}` for each responses from API.